### PR TITLE
derive: Add cbor(as_struct) attribute for variants

### DIFF
--- a/derive/src/common.rs
+++ b/derive/src/common.rs
@@ -116,6 +116,9 @@ pub struct Variant {
     #[darling(default, rename = "as_array")]
     pub as_array: Flag,
 
+    #[darling(default, rename = "as_struct")]
+    pub as_struct: Flag,
+
     #[darling(default, rename = "skip")]
     pub skip: Flag,
 }

--- a/derive/src/decode.rs
+++ b/derive/src/decode.rs
@@ -199,7 +199,7 @@ fn derive_enum(dec: &Codable, variants: Vec<&Variant>) -> TokenStream {
 
     // Generate decoders for all unit variants.
     let unit_decoders = variants.iter().filter_map(|variant| {
-        if !variant.fields.is_unit() {
+        if !variant.fields.is_unit() || variant.as_struct.is_some() {
             return None;
         }
         if variant.skip.is_some() {
@@ -228,7 +228,7 @@ fn derive_enum(dec: &Codable, variants: Vec<&Variant>) -> TokenStream {
     let non_unit_decoders: Vec<_> = variants
         .iter()
         .filter_map(|variant| {
-            if variant.fields.is_unit() {
+            if variant.fields.is_unit() && !variant.as_struct.is_some() {
                 return None;
             }
             if variant.skip.is_some() {


### PR DESCRIPTION
This allows one to encode/decode unit variants as empty maps instead of
as discriminant values directly.