### PR TITLE
Multiple breaking changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "oasis-cbor"
 description = "Rust CBOR serialization built as a thin wrapper around sk-cbor."
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Oasis Protocol Foundation <info@oasisprotocol.org>"]
 repository = "https://github.com/oasisprotocol/oasis-cbor"
 readme = "README.md"
@@ -11,7 +11,7 @@ keywords = ["cbor", "serialization"]
 categories = ["encoding"]
 
 [dependencies]
-oasis-cbor-derive = { path = "derive", version = "0.2.1" }
+oasis-cbor-derive = { path = "derive", version = "0.3.0" }
 
 # Third party.
 thiserror = "1.0.25"

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "oasis-cbor-derive"
 description = "Procedural macros for oasis-cbor."
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Oasis Protocol Foundation <info@oasisprotocol.org>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/derive/src/common.rs
+++ b/derive/src/common.rs
@@ -83,6 +83,12 @@ pub struct Field {
 
     #[darling(default, rename = "skip_serializing_if")]
     pub skip_serializing_if: Option<Path>,
+
+    #[darling(default, rename = "serialize_with")]
+    pub serialize_with: Option<Path>,
+
+    #[darling(default, rename = "deserialize_with")]
+    pub deserialize_with: Option<Path>,
 }
 
 impl Field {

--- a/derive/src/common.rs
+++ b/derive/src/common.rs
@@ -21,6 +21,13 @@ pub struct Codable {
 
     #[darling(default, rename = "as_array")]
     pub as_array: Flag,
+
+    #[darling(default, rename = "no_default")]
+    pub no_default: Flag,
+
+    // TODO: Add exclusion check after bump to darling 0.14.x.
+    #[darling(default, rename = "with_default")]
+    pub with_default: Flag,
 }
 
 pub enum Key {
@@ -74,9 +81,6 @@ pub struct Field {
 
     #[darling(default, rename = "optional")]
     pub optional: Flag,
-
-    #[darling(default, rename = "default")]
-    pub default: Flag,
 
     #[darling(default, rename = "skip")]
     pub skip: Flag,

--- a/derive/src/encode.rs
+++ b/derive/src/encode.rs
@@ -180,9 +180,8 @@ fn derive_struct(
                         match &field.skip_serializing_if {
                             None => {
                                 quote! {
-                                    let fv = #field_value;
-                                    if fv != __cbor::Value::Simple(__cbor::SimpleValue::NullValue) {
-                                        fields.push((#key, fv));
+                                    if !__cbor::Encode::is_empty(&#field_binding) {
+                                        fields.push((#key, #field_value));
                                     }
                                 }
                             }

--- a/derive/src/encode.rs
+++ b/derive/src/encode.rs
@@ -129,17 +129,6 @@ fn derive_struct(
             .iter()
             .enumerate()
             .map(|(i, field)| {
-                // Perform early validation for option compatibility.
-                if field.optional.is_some() && as_array {
-                    field
-                        .ident
-                        .span()
-                        .unwrap()
-                        .error("cannot use optional attribute in arrays".to_string())
-                        .emit();
-                    return quote!({});
-                }
-
                 if field.skip.is_some() {
                     // Skip serializing this field.
                     return quote!();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,7 @@ where
     T: Decode,
 {
     let value = reader::read_nested(data, Some(MAX_NESTING_LEVEL))?;
-    T::try_from_cbor_value(value)
+    T::try_from_cbor_value_default(value)
 }
 
 /// Convert high-level CBOR representation into the given type.
@@ -60,7 +60,7 @@ pub fn from_value<T>(value: Value) -> Result<T, DecodeError>
 where
     T: Decode,
 {
-    T::try_from_cbor_value(value)
+    T::try_from_cbor_value_default(value)
 }
 
 /// Convert the given type into its CBOR-encoded representation.

--- a/tests/derive_test.rs
+++ b/tests/derive_test.rs
@@ -1,10 +1,10 @@
 extern crate alloc;
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 
 use oasis_cbor as cbor;
 
-#[derive(Debug, Clone, Eq, PartialEq, cbor::Encode, cbor::Decode)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, cbor::Encode, cbor::Decode)]
 struct A {
     foo: u64,
     bar: String,
@@ -16,13 +16,14 @@ struct A {
     renamed: bool,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, cbor::Encode, cbor::Decode)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, cbor::Encode, cbor::Decode)]
 struct B {
     foo: u64,
     bytes: Vec<u8>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, cbor::Encode, cbor::Decode)]
+#[cbor(with_default)]
 enum C {
     One = 1,
     Two = 2,
@@ -30,6 +31,12 @@ enum C {
     Four,
     #[cbor(rename = "five")]
     Five,
+}
+
+impl Default for C {
+    fn default() -> Self {
+        Self::One
+    }
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, cbor::Encode, cbor::Decode)]
@@ -47,22 +54,23 @@ enum D {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, cbor::Encode, cbor::Decode)]
+#[cbor(no_default)]
 struct E(u64, String, bool);
 
-#[derive(Debug, Clone, Eq, PartialEq, cbor::Encode, cbor::Decode)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, cbor::Encode, cbor::Decode)]
 #[cbor(transparent)]
 struct Transparent(u64);
 
-#[derive(Debug, Clone, Eq, PartialEq, cbor::Encode, cbor::Decode)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, cbor::Encode, cbor::Decode)]
 struct NonTransparent(u64);
 
-#[derive(Debug, Clone, Eq, PartialEq, cbor::Encode, cbor::Decode)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, cbor::Encode, cbor::Decode)]
 struct WithOptionalDefault {
-    #[cbor(optional, default, skip_serializing_if = "String::is_empty")]
+    #[cbor(optional, skip_serializing_if = "String::is_empty")]
     bar: String,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, cbor::Encode, cbor::Decode)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, cbor::Encode, cbor::Decode)]
 struct WithOptional {
     #[cbor(optional)]
     bar: String,
@@ -74,14 +82,14 @@ enum Untagged {
     First { a: u64, b: u64 },
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, cbor::Encode, cbor::Decode)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, cbor::Encode, cbor::Decode)]
 #[cbor(as_array)]
 struct AsArray {
     foo: u64,
     bytes: Vec<u8>,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq)] // No cbor::{Encode, Decode}!
+#[derive(Debug, Default, Clone, Eq, PartialEq)] // No cbor::{Encode, Decode}!
 struct CustomType(String);
 
 impl CustomType {
@@ -94,7 +102,7 @@ fn decode_custom_type(value: String) -> Result<CustomType, cbor::DecodeError> {
     Ok(CustomType(value))
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, cbor::Encode, cbor::Decode)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, cbor::Encode, cbor::Decode)]
 struct CustomEncodeDecode {
     #[cbor(
         serialize_with = "CustomType::as_str",
@@ -103,7 +111,7 @@ struct CustomEncodeDecode {
     foo: CustomType,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, cbor::Encode, cbor::Decode)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, cbor::Encode, cbor::Decode)]
 #[cbor(as_array)]
 struct CustomEncodeDecodeArray {
     #[cbor(
@@ -398,8 +406,14 @@ fn test_missing_field() {
         0x66, 0x6F, 0x6F, // "foo"
         0x0A, // unsigned(10)
     ];
-    let res: Result<B, _> = cbor::from_slice(&b_without_bytes);
-    assert!(matches!(res, Err(cbor::DecodeError::MissingField)));
+    let res: B = cbor::from_slice(&b_without_bytes).unwrap();
+    assert_eq!(
+        res,
+        B {
+            foo: 10,
+            bytes: vec![],
+        }
+    )
 }
 
 #[test]
@@ -520,8 +534,11 @@ fn test_with_default() {
     let dec: WithOptionalDefault = cbor::from_slice(&[0xA0]).unwrap();
     assert_eq!(dec, WithOptionalDefault { bar: "".to_owned() });
 
-    let dec: Result<WithOptional, _> = cbor::from_slice(&[0xA0]);
-    assert!(matches!(dec, Err(cbor::DecodeError::UnexpectedType)));
+    let dec: WithOptional = cbor::from_slice(&[0xA0]).unwrap();
+    assert_eq!(dec, WithOptional { bar: "".to_owned() });
+    let wo = WithOptional { bar: "".to_owned() };
+    let enc = cbor::to_vec(wo);
+    assert_eq!(enc, vec![0xA0]);
 
     let wod = WithOptionalDefault { bar: "".to_owned() };
     let enc = cbor::to_vec(wod);
@@ -893,4 +910,83 @@ fn test_custom_encode_decode_array() {
     let dec: CustomEncodeDecodeArray =
         cbor::from_slice(&enc).expect("serialization should round-trip");
     assert_eq!(dec, ct);
+}
+
+#[test]
+fn test_null_decode() {
+    fn decode_from_null<T: cbor::Decode + Default + std::fmt::Debug + PartialEq>() {
+        let data = vec![0xf6]; // Null.
+        let dec1: T = cbor::from_slice(&data).expect(&format!(
+            "type {} can be decoded from CBOR null",
+            std::any::type_name::<T>()
+        ));
+
+        let data = vec![0xf7]; // Undefined.
+        let dec2: T = cbor::from_slice(&data).expect(&format!(
+            "type {} can be decoded from CBOR undefined",
+            std::any::type_name::<T>()
+        ));
+
+        assert_eq!(dec1, dec2);
+        assert_eq!(dec1, Default::default());
+    }
+
+    fn decode_from_null_special<T: cbor::Decode + std::fmt::Debug + PartialEq>(value: T) {
+        let data = vec![0xf6]; // Null.
+        let dec1: T = cbor::from_slice(&data).expect(&format!(
+            "type {} can be decoded from CBOR null",
+            std::any::type_name::<T>()
+        ));
+
+        let data = vec![0xf7]; // Undefined.
+        let dec2: T = cbor::from_slice(&data).expect(&format!(
+            "type {} can be decoded from CBOR undefined",
+            std::any::type_name::<T>()
+        ));
+
+        assert_eq!(dec1, dec2);
+        assert_eq!(dec1, value);
+    }
+
+    fn not_decode_from_null<T: cbor::Decode + std::fmt::Debug>() {
+        let data = vec![0xf6]; // Null.
+        cbor::from_slice::<T>(&data).expect_err(&format!(
+            "type {} should not be decoded from CBOR null",
+            std::any::type_name::<T>()
+        ));
+
+        let data = vec![0xf7]; // Undefined.
+        cbor::from_slice::<T>(&data).expect_err(&format!(
+            "type {} should not be decoded from CBOR undefined",
+            std::any::type_name::<T>()
+        ));
+    }
+
+    decode_from_null::<A>();
+    decode_from_null::<B>();
+    decode_from_null::<C>();
+    decode_from_null::<bool>();
+    decode_from_null::<u8>();
+    decode_from_null::<u32>();
+    decode_from_null::<u128>();
+    decode_from_null::<i8>();
+    decode_from_null::<i32>();
+    decode_from_null::<String>();
+    decode_from_null::<Vec<u8>>();
+    decode_from_null::<Vec<String>>();
+    decode_from_null::<BTreeMap<String, String>>();
+    decode_from_null::<BTreeSet<String>>();
+    decode_from_null::<HashMap<String, String>>();
+    decode_from_null::<HashSet<String>>();
+    decode_from_null::<Option<String>>();
+    decode_from_null::<()>();
+    decode_from_null::<[u8; 32]>();
+
+    decode_from_null_special::<cbor::Value>(cbor::Value::Simple(cbor::SimpleValue::NullValue));
+
+    not_decode_from_null::<[u16; 32]>();
+    not_decode_from_null::<[String; 32]>();
+    not_decode_from_null::<D>();
+    not_decode_from_null::<E>(); // Tagged with cbor(no_default).
+}
 }

--- a/tests/derive_test.rs
+++ b/tests/derive_test.rs
@@ -989,4 +989,52 @@ fn test_null_decode() {
     not_decode_from_null::<D>();
     not_decode_from_null::<E>(); // Tagged with cbor(no_default).
 }
+
+#[test]
+fn encode_empty() {
+    fn encode_is_empty<T: cbor::Encode>(value: T) {
+        #[derive(cbor::Encode)]
+        struct WithField<U: cbor::Encode> {
+            #[cbor(optional)]
+            field: U,
+        }
+
+        let enc = cbor::to_vec(WithField { field: value });
+        assert_eq!(enc, vec![0xA0]) // {}
+    }
+
+    encode_is_empty(false);
+    encode_is_empty(0u8);
+    encode_is_empty(0u16);
+    encode_is_empty(0u32);
+    encode_is_empty(0u64);
+    encode_is_empty(0u128);
+    encode_is_empty(0i8);
+    encode_is_empty(0i16);
+    encode_is_empty(0i32);
+    encode_is_empty(0i64);
+    encode_is_empty(&0u8);
+    encode_is_empty(&0u16);
+    encode_is_empty(&0u32);
+    encode_is_empty(&0u64);
+    encode_is_empty(&0u128);
+    encode_is_empty(&0i8);
+    encode_is_empty(&0i16);
+    encode_is_empty(&0i32);
+    encode_is_empty(&0i64);
+    encode_is_empty(String::new());
+    encode_is_empty("");
+    encode_is_empty(None::<String>);
+    encode_is_empty(vec![]);
+    encode_is_empty(BTreeMap::<String, String>::new());
+    encode_is_empty(BTreeSet::<String>::new());
+    encode_is_empty(HashMap::<String, String>::new());
+    encode_is_empty(HashSet::<String>::new());
+    encode_is_empty(());
+    encode_is_empty((false, 0u8));
+    encode_is_empty((false, 0u8, String::new()));
+    encode_is_empty((false, 0u8, String::new(), 0i64));
+    encode_is_empty((false, 0u8, 0u16, 0u128, vec![]));
+    encode_is_empty(cbor::Value::Simple(cbor::SimpleValue::NullValue));
+    encode_is_empty(cbor::Value::Simple(cbor::SimpleValue::Undefined));
 }


### PR DESCRIPTION
Fixes #23 

* Add support for deriving custom field (de)serialization via `serialize_with`/`deserialize_with` attributes.
* More permissive decoding from CBOR NULL/undefined values. A `Default` implementation is now required on all derived structures (unless overriden via the `no_default` attribute). This also removes the `default` attribute on the fields.
* Add `Encode::is_empty` to determine what can be omitted if marked with the `optional` attribute.

Since this is breaking, the version is bumped to `0.3.0`.