### PR TITLE
derive: allow alternate forms of importing oasis_cbor

### DIFF
--- a/derive/src/util.rs
+++ b/derive/src/util.rs
@@ -13,14 +13,18 @@ pub fn wrap_in_const(tokens: TokenStream) -> TokenStream {
 }
 
 pub fn cbor_crate_identifier() -> TokenStream {
-    let found_crate =
-        crate_name("oasis-cbor").expect("oasis-cbor should be imported in `Cargo.toml`");
+    let found_crate = crate_name("oasis-cbor");
 
     match found_crate {
-        FoundCrate::Itself => quote!(crate),
-        FoundCrate::Name(name) => {
+        Ok(FoundCrate::Itself) => quote!(crate),
+        Ok(FoundCrate::Name(name)) => {
             let ident = Ident::new(&name, Span::call_site());
             quote!( ::#ident )
         }
+        Err(proc_macro_crate::Error::CrateNotFound { .. }) => {
+            let ident = Ident::new("oasis_cbor", Span::call_site());
+            quote!(#ident)
+        }
+        Err(_) => panic!("oasis-cbor should be imported in `Cargo.toml`"),
     }
 }


### PR DESCRIPTION
This PR makes the import location of `oasis_cbor` less restrictive so that you can import it from a prelude package, for example.

I got annoyed at having to import six different `oasis-contract-sdk-flimflam`s in each of several crates, so I put `pub use oasis_cbor` into a crate. The issue then was that this macro requires `oasis_cbor` to be a direct dependency, so I went ahead and relaxed that requirement.