### PR TITLE
Update actions/upload-artifact action to v4

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -32,11 +32,10 @@ jobs:
           components: rustfmt # rustfmt is required for macros tests.
           override: true
 
-      - name: Install cargo-tarpaulin
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libssl-dev
-          cargo install cargo-tarpaulin
+      - name: Install tarpaulin
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-tarpaulin@0.25.1
 
       - name: Run tests with coverage
         run: |


### PR DESCRIPTION
`actions/upload-artifact` v1/v2 is dead already and v3 will reach EOL on January 31st

`actions-rs/tarpaulin@v0.1` is dead already too